### PR TITLE
No longer use the executables current directory to store data. Use the user's application data home.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1191,10 +1191,10 @@ void MapPort(bool)
 // The first name is used as information source for addrman.
 // The second name should resolve to a list of seed addresses.
 static const char *strMainNetDNSSeed[][2] = {
-    {"81.98.168.158", "81.98.168.158"},
-    {"37.187.3.19", "37.187.3.19"},
-    {"198.52.200.3", "198.52.200.3"},
-    {"108.61.10.90", "108.61.10.90"},
+    {"seed.donationcoin.org", "seed.donationcoin.org"},
+    {"seed2.donationcoin.org", "seed2.donationcoin.org"},
+    {"seed3.donationcoin.org", "seed3.donationcoin.org"},
+    {"seed4.donationcoin.org", "seed4.donationcoin.org"},
     {NULL, NULL,}
 };
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1030,7 +1030,30 @@ void PrintExceptionContinue(std::exception* pex, const char* pszThread)
 boost::filesystem::path GetDefaultDataDir()
 {
     namespace fs = boost::filesystem;
-    return fs::path(".");
+    // Windows < Vista: C:\Documents and Settings\Username\Application Data\donationcoin
+    // Windows >= Vista: C:\Users\Username\AppData\Roaming\donationcoin
+    // Mac: ~/Library/Application Support/donationcoin
+    // Unix: ~/.donationcoin
+#ifdef WIN32
+    // Windows
+    return GetSpecialFolderPath(CSIDL_APPDATA) / "donationcoin";
+#else
+    fs::path pathRet;
+    char* pszHome = getenv("HOME");
+    if (pszHome == NULL || strlen(pszHome) == 0)
+        pathRet = fs::path("/");
+    else
+        pathRet = fs::path(pszHome);
+#ifdef MAC_OSX
+    // Mac
+    pathRet /= "Library/Application Support";
+    fs::create_directory(pathRet);
+    return pathRet / "donationcoin";
+#else
+    // Unix
+    return pathRet / ".donationcoin";
+#endif
+#endif
 }
 
 const boost::filesystem::path &GetDataDir(bool fNetSpecific)


### PR DESCRIPTION
…er home data directories.

// Windows < Vista: C:\Documents and Settings\Username\Application Data\donationcoin
// Windows >= Vista: C:\Users\Username\AppData\Roaming\donationcoin
// Mac: ~/Library/Application Support/donationcoin
// Unix: ~/.donationcoin
